### PR TITLE
feat(ci): add winget manifest automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ matrix.target }}
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
-          tag: nightly
+          tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'nightly' }}
           allowUpdates: true
       - name: wait
         run: |
@@ -57,3 +57,16 @@ jobs:
       - name: install.sh
         run: |
           bash ./install.sh
+
+  winget:
+    name: Publish to WinGet
+    runs-on: windows-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Submit to WinGet
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: 'easy-install.easy-install'
+          installers-regex: '.*windows-msvc.*\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ A cross-platform command-line tool for effortlessly installing binaries from Git
 
 ### Windows
 
+Using Windows Package Manager (WinGet):
+```powershell
+winget install easy-install
+```
+
+Using PowerShell directly:
 ```powershell
 powershell -ExecutionPolicy Bypass -c "irm https://github.com/easy-install/easy-install/releases/latest/download/install.ps1 | iex"
 ```


### PR DESCRIPTION
## Summary

- Adds a `winget` job to the release workflow that auto-submits updated manifests to `microsoft/winget-pkgs` on stable releases via `vedantmgoyal9/winget-releaser@v2`
- Adds `winget install easy-install.easy-install` to README.md and INSTALL.md installation docs
- Adds `winget uninstall easy-install.easy-install` to INSTALL.md binary removal section

## Prerequisites

Before this automation works, the repo owner needs to:
1. Create a GitHub PAT (classic) with `public_repo` scope
2. Add it as repo secret `WINGET_TOKEN`

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors in CI)
- [ ] Verify `winget` job only runs on stable releases (`!inputs.prerelease` guard)
- [ ] After merge + next stable release: confirm auto-PR appears in `microsoft/winget-pkgs`

## Note
`easy-install` is already available in winget, which is a prerequisite for using the winget-releaser action